### PR TITLE
Fix global CSS import path

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import '../styles/globals.css';
+import '../src/App.css';
 import { ChakraProvider } from '@chakra-ui/react';
 import theme from '../src/theme';
 

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import { ModalProvider } from './ModalContext';
 import firebase from './firebaseConfig';
-import './App.css';
 import OnboardingModal from './components/OnboardingModal';
 import HomePage from './pages/HomePage';
 import LandingPage from './pages/LandingPage';


### PR DESCRIPTION
## Summary
- remove global CSS import from `src/App.js`
- load that stylesheet from `pages/_app.js` instead

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737ab5ec58832faa4aa5f77944d1f1